### PR TITLE
Wasn't 0 index, couldn't delete first item in list

### DIFF
--- a/app/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
+++ b/app/src/main/java/com/bignerdranch/android/criminalintent/CrimeListFragment.java
@@ -119,7 +119,7 @@ public class CrimeListFragment extends BaseFragment {
                     // not after. No idea why, but it crashes.
                     actionMode.finish();
 
-                    for (int i = mCrimes.size(); i > 0; i--) {
+                    for (int i = mCrimes.size()-1; i >= 0; i--) {
                         if (mMultiSelector.isSelected(i, 0)) {
                             Crime crime = mCrimes.get(i);
                             CrimeLab.get(getActivity()).deleteCrime(crime);


### PR DESCRIPTION
Now can delete first item in list. Method should never be called without item in list, so size()-1 should never < 0.
